### PR TITLE
Swap real/imag constants for negative G2 generator

### DIFF
--- a/contracts/BN256G2.sol
+++ b/contracts/BN256G2.sol
@@ -20,10 +20,10 @@ library BN256G2 {
   uint internal constant PTZY = 5;
 
   // This is the generator negated, to use for pairing
-  uint256 public constant G2_NEG_X_RE  = 0x198E9393920D483A7260BFB731FB5D25F1AA493335A9E71297E485B7AEF312C2;
-  uint256 public constant G2_NEG_X_IM  = 0x1800DEEF121F1E76426A00665E5C4479674322D4F75EDADD46DEBD5CD992F6ED;
-  uint256 public constant G2_NEG_Y_RE  = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
-  uint256 public constant G2_NEG_Y_IM  = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d;
+  uint256 public constant G2_NEG_X_IM  = 0x198E9393920D483A7260BFB731FB5D25F1AA493335A9E71297E485B7AEF312C2;
+  uint256 public constant G2_NEG_X_RE  = 0x1800DEEF121F1E76426A00665E5C4479674322D4F75EDADD46DEBD5CD992F6ED;
+  uint256 public constant G2_NEG_Y_IM  = 0x275dc4a288d1afb3cbb1ac09187524c7db36395df7be3b99e673b13a075a65ec;
+  uint256 public constant G2_NEG_Y_RE  = 0x1d9befcd05a5323e6da4d435f3b617cdb3af83285c2df711ef39c01571827f9d;
 
   /**
   * @notice Add two twist points


### PR DESCRIPTION
The G2_NEG constants have the imaginary and real components switched.

This commit brings the G2_NEG_* constants into conformance with
https://eips.ethereum.org/EIPS/eip-197

It also ensures G2_NEG is on the curve.
