### PR TITLE
Fix MODEXP precompile success validation

### DIFF
--- a/contracts/BN256G2.sol
+++ b/contracts/BN256G2.sol
@@ -370,7 +370,8 @@ library BN256G2 {
       mstore(add(freemem,0x60), a)
       mstore(add(freemem,0x80), sub(n, 2))
       mstore(add(freemem,0xA0), n)
-      success := staticcall(sub(gas(), 2000), 5, freemem, 0xC0, freemem, 0x20)
+      pop(staticcall(sub(gas(), 2000), 5, freemem, 0xC0, freemem, 0x20))
+      success := eq(returndatasize(), 0x20)
       result := mload(freemem)
     }
     require(success, "error calculating the modular inverse");


### PR DESCRIPTION
`MODEXP` precompile always return success, but `returndatasize()` is 0 on failure.

Few more things to consider:
- Include `sub(n, 2)` underflow check into success: `success := and(gt(n, 1), eq(returndatasize(), 0x20))`
- Using `0` instead of `freemem` for call output memory pointer will be few gas cheaper